### PR TITLE
Updated icon paths for 2021/03/01 update to Fallen London

### DIFF
--- a/src/items/DummiedItem.jsx
+++ b/src/items/DummiedItem.jsx
@@ -38,7 +38,7 @@ export default class DummiedItem extends Component {
             onMouseLeave={this.handleMouseLeave}
             onMouseMove={this.handleMouseMove}
             ref={(element) => { this.element = element; }}
-            src={`${IMAGE_ROOT}/${image}.png`}
+            src={`${IMAGE_ROOT}/${image}small.png`}
           />
           <span className="js-item-value icon__value">{level}</span>
         </div>

--- a/src/items/Item.jsx
+++ b/src/items/Item.jsx
@@ -6,7 +6,7 @@ import MatchingItem from './MatchingItem';
 import MissingItem from './MissingItem';
 import { findMatch } from './selectors';
 
-export const IMAGE_ROOT = '//images.fallenlondon.com/images/icons_small';
+export const IMAGE_ROOT = '//images.fallenlondon.com/icons';
 
 function Item({ alwaysConvertible, enablementPreference, match, id }) {
   if (!match) {

--- a/src/items/UsableItem.jsx
+++ b/src/items/UsableItem.jsx
@@ -62,7 +62,7 @@ export default class UsableItem extends Component {
               >
                 <img
                   alt={name}
-                  src={`${IMAGE_ROOT}/${image}.png`}
+                  src={`${IMAGE_ROOT}/${image}small.png`}
                 />
               </a>
               <span className="js-item-value icon__value">{level}</span>


### PR DESCRIPTION
Icon path structure changed in the March 1st 2021 site update, but individual icon names remained the same, so a simple update is sufficient to correctly display them again.